### PR TITLE
136 user does not show as logged in when moving off of homepage

### DIFF
--- a/controllers/api/game-routes.js
+++ b/controllers/api/game-routes.js
@@ -1,7 +1,7 @@
 const router = require("express").Router();
 const { Chatroom } = require("../../models");
 const Game = require("../../models/Game");
-
+const withAuth = require("../../utils/auth.js");
 
 // GET all games
 router.get("/", async (req, res) => {
@@ -14,7 +14,7 @@ router.get("/", async (req, res) => {
 });
 
 // GET a game by ID
-router.get("/:id", async (req, res) => {
+router.get("/:id", withAuth, async (req, res) => {
   try {
     const allGameData = await Game.findAll();
     const games = allGameData.map((game) => game.get({ plain: true }));
@@ -86,6 +86,5 @@ router.delete("/:id", async (req, res) => {
     res.status(500).json({ error: "Failed to delete the game" });
   }
 });
-
 
 module.exports = router;

--- a/controllers/api/game-routes.js
+++ b/controllers/api/game-routes.js
@@ -33,7 +33,11 @@ router.get("/:id", withAuth, async (req, res) => {
 
     const game = gameData.get({ plain: true });
     console.log(game);
-    res.render("chatboard", { game, randomGames });
+    res.render("chatboard", {
+      loggedIn: req.session.loggedIn,
+      game,
+      randomGames,
+    });
   } catch (error) {
     res.status(500).json({ error: "Failed to retrieve the game" });
   }


### PR DESCRIPTION
## Purpose

Logged in users were not showing as logged in when moving to a games page.

Fixes #[136]

## Changes

Added logged in authorization to the /api/games/:id get route.

## Steps to Reproduce or Test

Logging in before moving to one of the chatboard pages will now show in the top right that you are logged in, and will show logout button.